### PR TITLE
Create Github action to build and push the image to docker hub.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,56 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+
+env:
+  # Replace with your actual Docker Hub repository name if different
+  DOCKER_IMAGE: orkaa/diun-dash
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Optional: Set up QEMU for multi-architecture builds (e.g., linux/arm64 for Raspberry Pi)
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha,format=short
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          # Uncomment the platforms line below to build for both AMD64 and ARM64
+          # platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache,mode=max


### PR DESCRIPTION
Here is a complete GitHub Action workflow to build and push the diun-dash image to Docker Hub. This workflow will satisfy the TODO listed in the repository's `README.md`.

It is designed to automatically trigger whenever code is pushed to the main branch or when a new version tag (e.g., v1.0.0) is published.

There are two things you will need to do:

1. Verify you like all the settings in the `.github/workflows/docker-publish.yml`. Feel free to remove, comment, or uncomment settings.

2. Configure GitHub Secrets

Before this action can successfully run, you need to provide GitHub with the credentials to authenticate with Docker Hub.

1. Go to your GitHub repository.
2. Navigate to Settings > Secrets and variables > Actions.
3. Click New repository secret and add the following two secrets:
    * `DOCKERHUB_USERNAME`: Your Docker Hub username.
    * `DOCKERHUB_TOKEN`: A Docker Hub Personal Access Token.

**How this Workflow Behaves**

***Automatic Tagging***: It uses docker/metadata-action to dynamically generate tags. If you push to main, it builds the latest tag and a tag matching the short commit SHA (e.g., sha-a1b2c3d). If you publish a GitHub release with a tag like v1.2.0, it will automatically tag the Docker image as 1.2.0.

***Layer Caching***: It utilizes Docker Buildx caching (cache-from and cache-to) to push cache layers to the Docker registry. This will significantly speed up subsequent runs by reusing unchanged steps from the Dockerfile (like installing uv and Python dependencies).