### PR TITLE
Improve docker-publish workflow: test gate, PR builds, cleanup

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -1,0 +1,24 @@
+name: Run Tests
+description: Install dependencies and run the test suite
+
+runs:
+  using: composite
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: "0.8.17"
+
+    - name: Set up Python
+      run: uv python install 3.13
+      shell: bash
+
+    - name: Install dependencies
+      run: uv sync
+      shell: bash
+
+    - name: Run tests
+      run: ./scripts/test.sh
+      shell: bash
+      env:
+        DIUN_WEBHOOK_TOKEN: test

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,21 +20,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          version: "0.8.17"
-
-      - name: Set up Python
-        run: uv python install 3.13
-
-      - name: Install dependencies
-        run: uv sync
-
       - name: Run tests
-        run: ./scripts/test.sh
-        env:
-          DIUN_WEBHOOK_TOKEN: test
+        uses: ./.github/actions/run-tests
 
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -56,6 +59,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,27 +6,49 @@ on:
       - main
     tags:
       - 'v*.*.*'
+  pull_request:
+    branches:
+      - main
 
 env:
-  # Replace with your actual Docker Hub repository name if different
   DOCKER_IMAGE: orkaa/diun-dash
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.8.17"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run tests
+        run: ./scripts/test.sh
+        env:
+          DIUN_WEBHOOK_TOKEN: test
+
   build-and-push:
     runs-on: ubuntu-latest
+    needs: [test]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Optional: Set up QEMU for multi-architecture builds (e.g., linux/arm64 for Raspberry Pi)
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -39,7 +61,6 @@ jobs:
           images: ${{ env.DOCKER_IMAGE }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=branch
             type=semver,pattern={{version}}
             type=sha,format=short
 
@@ -47,9 +68,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
-          # Uncomment the platforms line below to build for both AMD64 and ARM64
-          # platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,19 +13,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
-    - name: Install uv
-      uses: astral-sh/setup-uv@v3
-      with:
-        version: "0.8.17"
-        
-    - name: Set up Python
-      run: uv python install 3.13
-      
-    - name: Install dependencies
-      run: uv sync
-      
+
     - name: Run tests
-      run: ./scripts/test.sh
-      env:
-        DIUN_WEBHOOK_TOKEN: test
+      uses: ./.github/actions/run-tests


### PR DESCRIPTION
## Summary

- **Test gate**: adds a `test` job (mirrors `test.yml`) that `build-and-push` depends on via `needs`, so a broken build can never be published
- **PR build check**: adds `pull_request` trigger so every PR gets a build-only run (login and push are skipped via `github.event_name != 'pull_request'`)
- **Remove QEMU**: multi-arch was commented out anyway, QEMU added ~30s of overhead for nothing
- **Remove redundant tag**: `type=ref,event=branch` was generating a `main` tag alongside `latest` on every main push — removed the duplicate

## Test plan

- [ ] Open a test PR and confirm the workflow runs build-only (no push to Docker Hub)
- [ ] Merge to main and confirm both `latest` and a short SHA tag appear on Docker Hub, but no `main` tag
- [ ] Confirm a failing test blocks the publish step