### PR TITLE
Add auto-versioning: minor bump on merge, manual major bump

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -1,0 +1,53 @@
+name: Auto Version
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump type
+        required: true
+        default: major
+        type: choice
+        options:
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Bump version and push tag
+        run: |
+          LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          LATEST=${LATEST:-v0.0.0}
+
+          MAJOR=$(echo $LATEST | sed 's/v//' | cut -d. -f1)
+          MINOR=$(echo $LATEST | cut -d. -f2)
+          PATCH=$(echo $LATEST | cut -d. -f3)
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+            PATCH=0
+          else
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          fi
+
+          NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "Bumping $LATEST → $NEW_TAG"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag $NEW_TAG
+          git push origin $NEW_TAG

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,6 @@ name: Build and Push Docker Image
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*.*.*'
   pull_request:
@@ -49,7 +47,7 @@ jobs:
         with:
           images: ${{ env.DOCKER_IMAGE }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest
             type=semver,pattern={{version}}
             type=sha,format=short
 


### PR DESCRIPTION
## Summary

- **`auto-version.yml`**: bumps the minor version on every push to main (e.g. `v1.3.0` → `v1.4.0`) by reading the latest git tag, incrementing, and pushing a new tag — which in turn triggers the Docker publish
- **Major bumps**: run the workflow manually via GitHub Actions → "Run workflow" and select `major`; resets minor/patch to 0 (e.g. `v1.4.2` → `v2.0.0`)
- **`docker-publish.yml`**: no longer triggers on branch pushes — only on `v*.*.*` tags and PRs; `latest` tag is now always applied since it only fires from version tags

## Flow after merge

```
merge to main → auto-version creates v1.4.0 → docker-publish fires → pushes latest, 1.4.0, 1.4, 1, <sha>
```

## Dependencies

Depends on PR #4.

## Test plan

- [ ] Merge a commit to main and confirm a new minor tag is created
- [ ] Confirm the new tag triggers docker-publish and `latest` is updated on Docker Hub
- [ ] Run workflow_dispatch and confirm major is bumped and minor/patch reset to 0