### PR TITLE
Fix: grant contents write permission for pushing git tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test]
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The release job needs `permissions: contents: write` to push git tags via GITHUB_TOKEN. Without it, `git push origin <tag>` exits with code 128.