### PR TITLE
Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         version: "0.8.17"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run tests
         uses: ./.github/actions/run-tests
@@ -37,7 +37,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -73,20 +73,20 @@ jobs:
           git push origin ${{ steps.version.outputs.git_tag }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.DOCKER_IMAGE }}
           tags: |
@@ -95,7 +95,7 @@ jobs:
             type=sha,format=short
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Run tests
       uses: ./.github/actions/run-tests


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v6
- Bump `astral-sh/setup-uv` v3 → v8.1.0 (project now uses pinned full versions instead of moving major tags)
- Bump `docker/setup-qemu-action` v3 → v4
- Bump `docker/setup-buildx-action` v3 → v4
- Bump `docker/login-action` v3 → v4
- Bump `docker/metadata-action` v5 → v6
- Bump `docker/build-push-action` v5 → v7

## Test plan
- [ ] `test` workflow passes with updated `actions/checkout@v6` and `setup-uv@v8.1.0`
- [ ] `release` workflow passes with all updated Docker actions
- [ ] No deprecation warnings appear in action logs